### PR TITLE
Tiny fix for misnamed macro, add a compile-test for it

### DIFF
--- a/delegate.hpp
+++ b/delegate.hpp
@@ -154,7 +154,7 @@ using detail::Delegate;
 #undef CB_FORWARD
 
 #define __CB_DELEGATE_INIT(instance, func) decltype(CB::detail::create_delegate(func))::bind<func>(instance)
-#define __CB_DELEGATE_FF(func) decltype(CB::detail::create_delegate(func))::bind<func>()
+#define __CB_DELEGATE_INIT_FF(func) decltype(CB::detail::create_delegate(func))::bind<func>()
 #define CB_DELEGATE_INIT __CB_DELEGATE_INIT
 #define CB_DELEGATE_FF __CB_DELEGATE_INIT_FF
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -60,8 +60,12 @@ int main(int argc, char **argv)
         printf("%d\n", b3(5));
 
     }
+    {
+        printf("\n");
+        E d = create_delegate_freefunction();
+        int val = 41;
+        printf("%d %d\n",d(val), val);
+    }
 
     return 0;
 }
-
-

--- a/test/routines.cpp
+++ b/test/routines.cpp
@@ -19,3 +19,7 @@ D create_delegate(Value &v)
     return d;
 }
 
+E create_delegate_freefunction() {
+    E d = CB_DELEGATE_FF(increment);
+    return d;
+}

--- a/test/routines.hpp
+++ b/test/routines.hpp
@@ -5,6 +5,7 @@
 using C = CB::StaticClosure<int (int), 64>;
 using C1 = CB::StaticClosure<int (int), 76>;
 using D = CB::Delegate<int (int)>;
+using E = CB::Delegate<int (int &)>;
 
 struct Value {
 
@@ -17,6 +18,11 @@ struct Value {
 
 };
 
+inline int increment(int &val) {
+    return val++;
+}
+
 C create_closure(int init, const char *text);
 C1 create_closure2(int init, const char *text);
 D create_delegate(Value &v);
+E create_delegate_freefunction();


### PR DESCRIPTION
Small macro name mismatch for static and free functions. 

By the way, this code is conceptually similar to marcmo/delegates#1, also zero dependencies, zero exceptions, c++11 with variadic templates, similarly concise.
